### PR TITLE
Fallback to broker_selector_first_available for broker_selector_usage

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -1142,6 +1142,10 @@ int broker_selector_usage(broker_cfg *brokers, int broker_cnt, int ready_cnt)
         best = i;
       }
     }
+    
+    if (brokers[best].ctx->standby_available == 0) {
+      return broker_selector_first_available(brokers, broker_cnt, ready_cnt);
+    }
 
     brokers[best].ctx->standby_only = 0;
     brokers[best].ctx->state = STATE_GET_COOKIE;


### PR DESCRIPTION
Due to a bug somewhere else, the usage of all brokers is set to 65535 (integer max), if more than two brokers are configured. The algorithm of broker_selector_usage fails, as it selects the first broker (line 1138: best = 0) if all usages are equal and does not check weather the first broker is available.

So I suggest this fallback to first_available. That algorithm works in case the usage values are useless, too.