### PR TITLE
Fix for more than 2 tunneldigger brokers:

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -203,6 +203,14 @@ typedef struct {
   time_t timer_resolving;
 } l2tp_context;
 
+// List of brokers
+typedef struct {
+    char *address;
+    char *port;
+    l2tp_context *ctx;
+  } broker_cfg;
+#define MAX_BROKERS 10
+
 // Forward declarations
 void context_delete_tunnel(l2tp_context *ctx);
 void context_close_tunnel(l2tp_context *ctx, uint8_t reason);
@@ -212,6 +220,8 @@ void context_send_raw_packet(l2tp_context *ctx, char *packet, uint8_t len);
 void context_send_reliable_packet(l2tp_context *ctx, uint8_t type, char *payload, uint8_t len);
 int context_setup_tunnel(l2tp_context *ctx, uint32_t peer_tunnel_id);
 void context_free(l2tp_context *ctx);
+void do_select_one(broker_cfg one_broker);
+void do_select(broker_cfg *brokers, int broker_cnt);
 
 static l2tp_context *main_context = NULL;
 static asyncns_t *asyncns_context = NULL;
@@ -473,6 +483,7 @@ void context_process_control_packet(l2tp_context *ctx)
   socklen_t endpoint_len = sizeof(endpoint);
   ssize_t bytes = recvfrom(ctx->fd, &buffer, sizeof(buffer), 0, (struct sockaddr*) &endpoint,
     &endpoint_len);
+
 
   /* a valid package must at least 6 byte long */
   if (bytes < 6)
@@ -917,7 +928,14 @@ void context_close_tunnel(l2tp_context *ctx, uint8_t reason)
   ctx->state = STATE_REINIT;
 }
 
-void context_process(l2tp_context *ctx)
+void do_select_one(broker_cfg one_broker)
+{
+  broker_cfg broker[1];
+  broker[0] = one_broker;
+  do_select(broker, 1);
+}
+
+void do_select(broker_cfg *brokers, int broker_cnt)
 {
   // Poll the file descriptor to see if anything is to be read/written
   fd_set rfds;
@@ -926,22 +944,34 @@ void context_process(l2tp_context *ctx)
   tv.tv_usec = 0;
 
   FD_ZERO(&rfds);
-  FD_SET(ctx->fd, &rfds);
-
   // Add descriptor for DNS resolution
   int nsfd = asyncns_fd(asyncns_context);
-  int nfds = nsfd > ctx->fd ? nsfd : ctx->fd;
+  int nfds = nsfd;
   FD_SET(nsfd, &rfds);
+
+  int i;
+  for (i = 0; i < broker_cnt; i++) {
+    l2tp_context *ctx = brokers[i].ctx;
+    FD_SET(ctx->fd, &rfds);
+    nfds = nfds > ctx->fd ? nfds : ctx->fd;
+  }
 
   int res = select(nfds + 1, &rfds, NULL, NULL, &tv);
   if (res == -1) {
     return;
   } else if (res) {
-    if (FD_ISSET(ctx->fd, &rfds))
-      context_process_control_packet(ctx);
-    else if (FD_ISSET(nsfd, &rfds))
+    for (i = 0; i < broker_cnt; i++) {
+      l2tp_context *ctx = brokers[i].ctx;
+      if (FD_ISSET(ctx->fd, &rfds))
+        context_process_control_packet(ctx);
+    }
+    if (FD_ISSET(nsfd, &rfds))
       asyncns_wait(asyncns_context, 0);
   }
+}
+
+void context_process(l2tp_context *ctx)
+{
 
   // Transmit packets if needed
   switch (ctx->state) {
@@ -1123,14 +1153,6 @@ void context_free(l2tp_context *ctx)
   free(ctx);
 }
 
-// List of brokers
-typedef struct {
-    char *address;
-    char *port;
-    l2tp_context *ctx;
-  } broker_cfg;
-#define MAX_BROKERS 10
-
 int broker_selector_usage(broker_cfg *brokers, int broker_cnt, int ready_cnt)
 {
     // Select the r'th available broker and use it to establish a tunnel
@@ -1142,7 +1164,7 @@ int broker_selector_usage(broker_cfg *brokers, int broker_cnt, int ready_cnt)
         best = i;
       }
     }
-    
+
     if (brokers[best].ctx->standby_available == 0) {
       return broker_selector_first_available(brokers, broker_cnt, ready_cnt);
     }
@@ -1347,6 +1369,7 @@ int main(int argc, char **argv)
     int ready_cnt = 0;
     for (;;) {
       ready_cnt = 0;
+      do_select(brokers, broker_cnt);
       for (i = 0; i < broker_cnt; i++) {
         context_process(brokers[i].ctx);
       }
@@ -1379,6 +1402,7 @@ int main(int argc, char **argv)
     int restart_timer = 0;
     time_t timer_establish = timer_now();
     for (;;) {
+      do_select_one(brokers[i]);
       context_process(main_context);
 
       if (main_context->state == STATE_REINIT) {


### PR DESCRIPTION
select() moved from context_process() to a new function do_select(),
so that packets get waited for for all brokers at once.
Sideeffect: some superfluous control packets will be sent in the
broker selection phase.