### PR TITLE
Fix usage computation for cases where the result is less than 256

### DIFF
--- a/broker/l2tp_broker.py
+++ b/broker/l2tp_broker.py
@@ -962,8 +962,9 @@ class TunnelManager(object):
 
     val = int( 1.0 * (len(self.tunnels) / (self.max_tunnels * 1.0)) * 65535)
     val = hex(val)[2:]
-    if len(val)  % 2 == 1:
+    while len(val) < 4:
       val = '0' + val
+    if len(val) > 4: val = 'ffff' # this should not be possible
 
     return binascii.unhexlify(val)
 


### PR DESCRIPTION
The old code would return i.e. '3f' if 1 of 1024 tunnels is used, which would be sent on the wire as '3f00'. The new code returns the correct value '003f'.

I can't say I entirely understood the way the values flow here (e..g, where data has to be binary, where it is a string, etc.). I tested this patch briefly on one of our gateways, and it had the desired effect -- the clients got the usage information I expected them to get. In particular, I did not even try to understand whether endianess is an issue anywhere here.