### PR TITLE
reflect deprecated status of this repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,8 @@
-Tunneldigger
-============
+DEPRECATED
+==========
 
-Tunneldigger is one of the projects of `wlan slovenija`_ open wireless network.
-It is a simple VPN tunneling solution based on L2TPv3 tunnels supported in
-recent Linux kernels.
+This is a **deprecated** fork of the `wlan slovenija`_ tunneldigger.
+For the current version, please go to the `upstream project`_.
 
 .. _wlan slovenija: https://wlan-si.net
-
-Documentation is found at:
-
-http://tunneldigger.readthedocs.org/
-
-For development *wlan slovenija* open wireless network `development Trac`_ is
-used, so you can see `existing open tickets`_ or `open a new one`_ there. Source
-code is available on GitHub_. If you have any questions or if you want to
-discuss the project, use `development mailing list`_.
-
-.. _development Trac: https://dev.wlan-si.net/wiki/Tunneldigger
-.. _existing open tickets: https://dev.wlan-si.net/report
-.. _open a new one: https://dev.wlan-si.net/newticket
-.. _GitHub: https://github.com/wlanslovenija/tunneldigger
-.. _development mailing list: https://wlan-si.net/lists/info/development
+.. _upstream project: https://github.com/wlanslovenija/tunneldigger


### PR DESCRIPTION
For example, this repo never got the [fixes for tunneldigger to work with newer kernels](https://github.com/wlanslovenija/tunneldigger/pull/64), as is required on Debian Stretch and later.